### PR TITLE
카드API연결, 상세통계기본

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "chart.js": "^4.4.6",
         "d3": "^7.9.0",
         "d3-cloud": "^1.2.7",
+        "dayjs": "^1.11.13",
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.5",
         "react-chartjs-2": "^5.2.0",
@@ -6786,6 +6787,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.7",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chart.js": "^4.4.6",
     "d3": "^7.9.0",
     "d3-cloud": "^1.2.7",
+    "dayjs": "^1.11.13",
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.5",
     "react-chartjs-2": "^5.2.0",
@@ -47,5 +48,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://a7894a85a5eb54ff49f84008db827179-527169829.us-east-1.elb.amazonaws.com:8888"
+  "proxy": "http://aa759aa7b53cf4b61b78025b0c40c462-977669052.us-east-1.elb.amazonaws.com:8888"
 }

--- a/src/App.css
+++ b/src/App.css
@@ -29,8 +29,55 @@ html, body {
 
 .좌측{
   width: 25%;
+  margin-left: 5%;
 }
 
+
+
 .우측{
-  width: 75%;
+  width: 70%;
+}
+
+/* .chatsearch{
+  text-align: center;
+  margin-top: 20px;
+} */
+.chatsearch {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+  padding: 15px;
+  background: #2d2d2d;
+  border-radius: 12px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.chatsearch input[type="text"] {
+  width: 100%;
+  padding: 12px 16px;
+  font-size: 16px;
+  color: #ffffff;
+  background: #1e1e1e;
+  border: 2px solid #444;
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.chatsearch input[type="text"]:focus {
+  border-color: #5c6bc0;
+  box-shadow: 0 0 8px rgba(92, 107, 192, 0.6);
+}
+
+.chatsearch p {
+  font-size: 14px;
+  color: #bbbbbb;
+  margin: 0;
+  text-align: right;
+}
+
+.chatsearch p span {
+  font-weight: bold;
+  color: #ffffff;
 }

--- a/src/component/analytics/ChatBox.js
+++ b/src/component/analytics/ChatBox.js
@@ -13,7 +13,7 @@ const ChatBox = ({ chatData }) => {
 
   return (
     <div className="chat-box">
-      <h2 className="chat-header">Real-time Live Chat</h2>
+      <h2 className="chat-header">실시간 채팅창</h2>
       <div className="chat-messages">
         {chatData.map((chat) => (
           <div

--- a/src/component/page/AnalyticsPage.css
+++ b/src/component/page/AnalyticsPage.css
@@ -107,3 +107,7 @@
 .dropdown-icon {
   font-size: 18px;
 }
+.chatsearch{
+  text-align: center;
+  margin-top: 20px;
+}

--- a/src/component/page/AnalyticsPage.js
+++ b/src/component/page/AnalyticsPage.js
@@ -107,6 +107,7 @@ const AnalyticsPage = () => {
   return (
     <div className="analytics-container">
       <div className="좌측">
+        <div className="chatsearch">
         <input
           type="text"
           placeholder="채팅 검색..."
@@ -114,7 +115,9 @@ const AnalyticsPage = () => {
           onChange={(e) => setSearchQuery(e.target.value)}
           className="chat-search"
         />
-        <p>총 채팅 수: {totalChatCount}</p> {/* 총 갯수 표시 */}
+        <p>총 채팅 수: {totalChatCount}</p> {/* 총 갯수 표시 */} 
+        </div>
+        
         <ChatBox chatData={filteredChatData} />
       </div>
       <div className="우측">

--- a/src/component/page/LiveBroadcastPage.css
+++ b/src/component/page/LiveBroadcastPage.css
@@ -131,7 +131,7 @@
 
 .live-broadcast-card-title {
   font-weight: 800;
-  font-size: 18px;
+  font-size: 16px;
   line-height: 22px;
   color: #ffffff;
 }


### PR DESCRIPTION
API엔드포인트 요청을 통해 videoid및 관련 정보들을 받아와 카드 컴포넌트를 구성. 카드 컴포넌트를 클릭시 해당데이터를
바탕으로 한 상세 정보 페이지인 analyticspage로 Link되게됨. 현제 '개요' section에서  좋아요수, 조회수, 방송시간을 넣어놓은 상태. 추후 그래프추이와 videoid를통해  라이브가아닌 동영상을 '콘텐츠'형태로 제공하려 생각중

채팅창부분에서 chat-search부분 css추가